### PR TITLE
fix: check if protocol exists

### DIFF
--- a/src/Random.js
+++ b/src/Random.js
@@ -238,8 +238,9 @@ function Random({ isAuthenticated, org, orgSlug, person }) {
       if (
         person.blog.indexOf("http://") !== 0 &&
         person.blog.indexOf("https://") !== 0
-      )
+      ) {
         person.blog = "https://" + person.blog;
+      }
       return (
         <>
           Has a website at <a href={person.blog}>{person.blog}</a>

--- a/src/Random.js
+++ b/src/Random.js
@@ -235,6 +235,11 @@ function Random({ isAuthenticated, org, orgSlug, person }) {
     }
 
     if (hint.type === HINT_SITE) {
+      if (
+        person.blog.indexOf("http://") != 0 &&
+        person.blog.indexOf("https://") != 0
+      )
+        person.blog = "https://" + person.blog;
       return (
         <>
           Has a website at <a href={person.blog}>{person.blog}</a>

--- a/src/Random.js
+++ b/src/Random.js
@@ -236,8 +236,8 @@ function Random({ isAuthenticated, org, orgSlug, person }) {
 
     if (hint.type === HINT_SITE) {
       if (
-        person.blog.indexOf("http://") != 0 &&
-        person.blog.indexOf("https://") != 0
+        person.blog.indexOf("http://") !== 0 &&
+        person.blog.indexOf("https://") !== 0
       )
         person.blog = "https://" + person.blog;
       return (


### PR DESCRIPTION
GitHub lets users input their profile URLs with or without the protocol, so if someone like me has a URL like `mahdyar.me` its link would go to `https://gitemon.netlify.app/<organization>/mahdyar.me` instead of `http(s)://mahdyar.me`.

The same as #5, just changed the protocol to `https` here.